### PR TITLE
Fix jre21 build for Android x86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build OpenJDK 17 for Android and iOS
+name: Build OpenJDK 21 for Android and iOS
 
 on:
   push:

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -31,7 +31,7 @@ if [ "$BUILD_IOS" != "1" ]; then
   platform_args="--with-toolchain-type=gcc \
     --with-freetype-include=$FREETYPE_DIR/include/freetype2 \
     --with-freetype-lib=$FREETYPE_DIR/lib \
-    "
+    --build=x86_64-unknown-linux-gnu \"
   AUTOCONF_x11arg="--x-includes=$ANDROID_INCLUDE/X11"
   AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
     AR=$AR \
@@ -96,7 +96,6 @@ fi
 #   --with-extra-cflags="$CPPFLAGS" \
 
 bash ./configure \
-    --build=x86_64-unknown-linux-gnu \
     --with-boot-jdk=$BOOT_JDK \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -96,6 +96,7 @@ fi
 #   --with-extra-cflags="$CPPFLAGS" \
 
 bash ./configure \
+    --build=x86_64-unknown-linux-gnu \
     --with-boot-jdk=$BOOT_JDK \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -31,7 +31,8 @@ if [ "$BUILD_IOS" != "1" ]; then
   platform_args="--with-toolchain-type=gcc \
     --with-freetype-include=$FREETYPE_DIR/include/freetype2 \
     --with-freetype-lib=$FREETYPE_DIR/lib \
-    --build=x86_64-unknown-linux-gnu \"
+    --build=x86_64-unknown-linux-gnu \
+    "
   AUTOCONF_x11arg="--x-includes=$ANDROID_INCLUDE/X11"
   AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
     AR=$AR \

--- a/clonejdk.sh
+++ b/clonejdk.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-git clone --depth 1 https://github.com/openjdk/jdk21u openjdk
+git clone --branch jdk21.0.1 --depth 1 https://github.com/openjdk/jdk21u openjdk

--- a/tarjdk.sh
+++ b/tarjdk.sh
@@ -5,7 +5,7 @@ set -e
 if [ "$BUILD_IOS" != "1" ]; then
 
 unset AR AS CC CXX LD OBJCOPY RANLIB STRIP CPPFLAGS LDFLAGS
-git clone https://github.com/termux/termux-elf-cleaner || true
+git clone --depth 1 -b 'v2.2.0' https://github.com/termux/termux-elf-cleaner || true
 cd termux-elf-cleaner
 autoreconf --install
 bash configure


### PR DESCRIPTION
Looks like that the compiler identified the wrong build platform. This bug only occurs when building x86. I don't know how it occurs, but this error can be fixed by add "--build=x86_64-unknown-linux-gnu".