### PR TITLE
fix: remove duplicate type definitions

### DIFF
--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -2519,6 +2519,6 @@ index be578a0bb..ce5e8b400 100644
  // not relying on included headers.
  
 -#ifndef __GLIBC__
-+#ifndef __GLIBC__ && __ANDROID__
++#if !defined(__GLIBC__) && !defined(__ANDROID__)
  // Alpine doesn't know these types, define them
  typedef unsigned int       __uint32_t;

--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -2519,6 +2519,6 @@ index be578a0bb..ce5e8b400 100644
  // not relying on included headers.
  
 -#ifndef __GLIBC__
-+#ifndef __GLIBC__ && !defined(__ANDROID__)
++#ifndef __GLIBC__ && __ANDROID__
  // Alpine doesn't know these types, define them
  typedef unsigned int       __uint32_t;

--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -2511,3 +2511,18 @@ index 3fb38893e..20ac7b270 100644
          }
  
          if (codeset == NULL) {
+diff --git a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+index be578a0bb..83055e696 100644
+--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
++++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+@@ -80,10 +80,4 @@
+ // not relying on included headers.
+ 
+-#ifndef __GLIBC__
+-// Alpine doesn't know these types, define them
+-typedef unsigned int       __uint32_t;
+-typedef unsigned short     __uint16_t;
+-typedef unsigned long int  __uint64_t;
+-#endif
+ 
+ /*

--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -2512,17 +2512,13 @@ index 3fb38893e..20ac7b270 100644
  
          if (codeset == NULL) {
 diff --git a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
-index be578a0bb..83055e696 100644
+index be578a0bb..ce5e8b400 100644
 --- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
 +++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
-@@ -80,10 +80,4 @@
+@@ -80,5 +80,5 @@
  // not relying on included headers.
  
 -#ifndef __GLIBC__
--// Alpine doesn't know these types, define them
--typedef unsigned int       __uint32_t;
--typedef unsigned short     __uint16_t;
--typedef unsigned long int  __uint64_t;
--#endif
- 
- /*
++#ifndef __GLIBC__ && !defined(__ANDROID__)
+ // Alpine doesn't know these types, define them
+ typedef unsigned int       __uint32_t;


### PR DESCRIPTION
This fixes the android build by removing type definitions, you may want to use a #ifndef __ANDROID__ instead