### PR TITLE
libnet: ipv6_support: skip some checks to provide android ipv6 support (for android 10 and newer)

### DIFF
--- a/patches/jre_17/android/16_fix_jni_util_md.diff
+++ b/patches/jre_17/android/16_fix_jni_util_md.diff
@@ -12,3 +12,24 @@ index 460503cd7..193480e73 100644
           (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L \
               && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600))
  extern int __xpg_strerror_r(int, char *, size_t);
+// skip some checks as AOSP does
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 4ec11a136..01b85db4d 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -129,6 +129,7 @@ jint  IPv6_supported()
+     SOCKETADDRESS sa;
+     socklen_t sa_len = sizeof(SOCKETADDRESS);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -172,6 +173,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /*
+      *  OK we may have the stack available in the kernel,

--- a/patches/jre_17/android/16_fix_jni_util_md.diff
+++ b/patches/jre_17/android/16_fix_jni_util_md.diff
@@ -12,24 +12,3 @@ index 460503cd7..193480e73 100644
           (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L \
               && defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600))
  extern int __xpg_strerror_r(int, char *, size_t);
-// skip some checks as AOSP does
-diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
-index 4ec11a136..01b85db4d 100644
---- a/src/java.base/unix/native/libnet/net_util_md.c
-+++ b/src/java.base/unix/native/libnet/net_util_md.c
-@@ -129,6 +129,7 @@ jint  IPv6_supported()
-     SOCKETADDRESS sa;
-     socklen_t sa_len = sizeof(SOCKETADDRESS);
- 
-+#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
-     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
-     if (fd < 0) {
-         /*
-@@ -172,6 +173,7 @@ jint  IPv6_supported()
-         }
-     }
- #endif
-+#endif  // !defined __ANDROID__
- 
-     /*
-      *  OK we may have the stack available in the kernel,

--- a/patches/jre_17/android/26_skip_proc_net_check.diff
+++ b/patches/jre_17/android/26_skip_proc_net_check.diff
@@ -1,0 +1,21 @@
+// skip some checks as AOSP does
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 4ec11a136..01b85db4d 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -129,6 +129,7 @@ jint  IPv6_supported()
+     SOCKETADDRESS sa;
+     socklen_t sa_len = sizeof(SOCKETADDRESS);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -172,6 +173,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /*
+      *  OK we may have the stack available in the kernel,

--- a/patches/jre_17/android/\
+++ b/patches/jre_17/android/\
@@ -1,0 +1,21 @@
+// skip some checks as AOSP does
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 4ec11a136..01b85db4d 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -129,6 +129,7 @@ jint  IPv6_supported()
+     SOCKETADDRESS sa;
+     socklen_t sa_len = sizeof(SOCKETADDRESS);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -172,6 +173,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /*
+      *  OK we may have the stack available in the kernel,

--- a/patches/jre_21/android/jdk21u_android.diff
+++ b/patches/jre_21/android/jdk21u_android.diff
@@ -2258,6 +2258,26 @@ index 21ef40688..b8c2520d2 100644
  #endif
  
      if (exec_path == NULL) {
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 4ec11a136..01b85db4d 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -129,6 +129,7 @@ jint  IPv6_supported()
+     SOCKETADDRESS sa;
+     socklen_t sa_len = sizeof(SOCKETADDRESS);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -172,6 +173,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /*
+      *  OK we may have the stack available in the kernel,
 diff --git a/src/java.base/unix/native/libnet/net_util_md.h b/src/java.base/unix/native/libnet/net_util_md.h
 index 902cf9673..3b8acd66b 100644
 --- a/src/java.base/unix/native/libnet/net_util_md.h


### PR DESCRIPTION
upd: this pr may only be able to fix read proc denied caused by selinux policy introduced around Android 10 (and affect all version newer) (ref:https://cs.android.com/android/_/android/platform/system/sepolicy/+/424517721cb71bc842cc37d82e8b61a6a4a6e00a)
THAT SAID IF U CAN RUN `cat /proc/net/if_inet6` WITHOUT ERROR BUT IPV6 STILL NOT WORKING, THAT PR MAY NOT WORK FOR YOU
(for example https://github.com/PojavLauncherTeam/PojavLauncher/issues/5125#issuecomment-2175568101)

this PR should solve https://github.com/PojavLauncherTeam/PojavLauncher/issues/5125 for Android version >= 10 and for those kernel doesn't restrict `socket(2)` call. 
(Though I don't know why just skip check **without touch selinux policy** would make ipv6 working, it _just_ works on my machine and seems aosp is doing the same thing (see issue above for reference))

![image](https://github.com/PojavLauncherTeam/android-openjdk-build-multiarch/assets/60149113/7f4a48dd-5155-48a5-9b64-8d8b5103b0c0)
![Screenshot_20240602-140911](https://github.com/PojavLauncherTeam/android-openjdk-build-multiarch/assets/60149113/308f64da-54b2-4439-9304-a53fae10a63b)

Maintainers may need to merge this commit to dev branch not a patch branch (or to say WIP branch).