### PR TITLE
libnet: ipv6_support: skip /proc/net/ & socket() check ifdef __ANDROID__

### DIFF
--- a/patches/jdk8u_android.diff
+++ b/patches/jdk8u_android.diff
@@ -59882,6 +59882,22 @@ index bd0bd8c2c9..f6273dff47 100644
  #include <arpa/inet.h>
  #include <net/route.h>
  #include <sys/utsname.h>
+@@ -319,6 +319,7 @@ jint  IPv6_supported()
+     SOCKADDR sa;
+     socklen_t sa_len = sizeof(sa);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = JVM_Socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -363,6 +364,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /**
+      * On Solaris 8 it's possible to create INET6 sockets even
 @@ -577,7 +581,9 @@ static void initLoopbackRoutes() {
           */
          if ( (dest_plen < 0 || dest_plen > 128)  ||


### PR DESCRIPTION
https://github.com/PojavLauncherTeam/android-openjdk-build-multiarch/pull/26 while targeting on jdk8.
This commit skips socket() check, it may misbehaves for old kernel that restricts `socket()`, would not affect the working part though.